### PR TITLE
fix missing nostr module error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bip39==0.0.2
 cffi==1.15.1
 cryptography==38.0.4
+nostr==0.0.1
 pycparser==2.21
 secp256k1==0.14.0


### PR DESCRIPTION
```
$ python3 startr_app.py
Traceback (most recent call last):
  File "/home/marcel/workspace/nostr_startr/startr_app.py", line 2, in <module>
    from helpers import *
  File "/home/marcel/workspace/nostr_startr/helpers.py", line 1, in <module>
    from nostr import bech32
ModuleNotFoundError: No module named 'nostr'
```